### PR TITLE
Fix max_resource_size calculation in World

### DIFF
--- a/src/world.zig
+++ b/src/world.zig
@@ -133,9 +133,9 @@ pub fn World(Components: anytype, Resources: anytype, Events: anytype) type {
         };
 
         pub const max_resource_size: comptime_int = blk: {
-            if (component_pool_length == 0) break :blk 1;
+            if (resource_pool_length == 0) break :blk 1;
             var max_size: comptime_int = 1;
-            for (component_fields) |field| {
+            for (resource_fields) |field| {
                 const size = @sizeOf(field.type);
                 if (size > max_size) max_size = size;
             }


### PR DESCRIPTION
…nt types

The World.max_resource_size constant was incorrectly checking component_pool_length and iterating over component_fields instead of resource_pool_length and resource_fields. This caused undersized buffer allocations when resources were larger than components or when a world had resources but no components.

Fixed by mirroring the max_component_size implementation but using resource metadata.