### PR TITLE
Fix serialize failing on invalid resources

### DIFF
--- a/src/serialization/world.zig
+++ b/src/serialization/world.zig
@@ -88,7 +88,13 @@ pub fn serialize(
         try w.writeInt(u16, resource_id, .little);
         try w.writeInt(u64, type_name_hash, .little);
 
-        // Always serialize as initialized (we assume all resources are set)
+        // Check if resource is initialized
+        const is_initialized = if (resource_fields.len > 0) world.resource_initialized.isSet(i) else false;
+        if (!is_initialized) {
+            return error.UninitializedResource;
+        }
+
+        // Serialize as initialized
         try w.writeInt(u8, 1, .little);
 
         // Serialize resource data
@@ -242,6 +248,11 @@ pub fn deserialize(
         // Deserialize resource data
         const Serializer = traits.getSerializer(Resource);
         world.resource_pool[i] = try Serializer.deserialize(r);
+
+        // Mark resource as initialized
+        if (resource_fields.len > 0) {
+            world.resource_initialized.set(i);
+        }
     }
 
     // Deserialize events (read buffer only)

--- a/src/serialization/world.zig
+++ b/src/serialization/world.zig
@@ -89,7 +89,13 @@ pub fn serialize(
         try w.writeInt(u64, type_name_hash, .little);
 
         // Check if resource is initialized
-        const is_initialized = if (resource_fields.len > 0) world.resource_initialized.isSet(i) else false;
+        const is_initialized = blk: {
+            if (comptime resource_fields.len == 0) {
+                break :blk false;
+            } else {
+                break :blk world.resource_initialized.isSet(i);
+            }
+        };
         if (!is_initialized) {
             return error.UninitializedResource;
         }
@@ -250,7 +256,7 @@ pub fn deserialize(
         world.resource_pool[i] = try Serializer.deserialize(r);
 
         // Mark resource as initialized
-        if (resource_fields.len > 0) {
+        if (comptime resource_fields.len > 0) {
             world.resource_initialized.set(i);
         }
     }

--- a/src/world.zig
+++ b/src/world.zig
@@ -354,7 +354,7 @@ pub fn World(Components: anytype, Resources: anytype, Events: anytype) type {
             const id = comptime getResourceId(R);
             // Mark resource as initialized when getting mutable pointer
             // This handles the case where users mutate resources in-place
-            if (resource_pool_length > 0) {
+            if (comptime resource_pool_length > 0) {
                 self.resource_initialized.set(id);
             }
             return &self.resource_pool[id];
@@ -363,7 +363,7 @@ pub fn World(Components: anytype, Resources: anytype, Events: anytype) type {
         pub fn setResource(self: *Self, comptime R: type, resource: R) !void {
             const id = comptime getResourceId(R);
             self.resource_pool[id] = resource;
-            if (resource_pool_length > 0) {
+            if (comptime resource_pool_length > 0) {
                 self.resource_initialized.set(id);
             }
         }
@@ -373,16 +373,19 @@ pub fn World(Components: anytype, Resources: anytype, Events: anytype) type {
         /// the resource can be serialized. Prefer using setResource() or getResourcePtrMut()
         /// which automatically mark resources as initialized.
         pub fn markResourceInitialized(self: *Self, comptime R: type) void {
-            if (resource_pool_length > 0) {
+            if (comptime resource_pool_length > 0) {
                 const id = comptime getResourceId(R);
                 self.resource_initialized.set(id);
             }
         }
 
         pub fn isResourceInitialized(self: *const Self, comptime R: type) bool {
-            if (resource_pool_length == 0) return false;
-            const id = comptime getResourceId(R);
-            return self.resource_initialized.isSet(id);
+            if (comptime resource_pool_length == 0) {
+                return false;
+            } else {
+                const id = comptime getResourceId(R);
+                return self.resource_initialized.isSet(id);
+            }
         }
 
         pub fn getEventStoragePtrMut(self: *Self, comptime E: type) *EventStorage(E) {

--- a/src/world.zig
+++ b/src/world.zig
@@ -352,6 +352,11 @@ pub fn World(Components: anytype, Resources: anytype, Events: anytype) type {
 
         pub fn getResourcePtrMut(self: *Self, comptime R: type) *R {
             const id = comptime getResourceId(R);
+            // Mark resource as initialized when getting mutable pointer
+            // This handles the case where users mutate resources in-place
+            if (resource_pool_length > 0) {
+                self.resource_initialized.set(id);
+            }
             return &self.resource_pool[id];
         }
 
@@ -359,6 +364,17 @@ pub fn World(Components: anytype, Resources: anytype, Events: anytype) type {
             const id = comptime getResourceId(R);
             self.resource_pool[id] = resource;
             if (resource_pool_length > 0) {
+                self.resource_initialized.set(id);
+            }
+        }
+
+        /// Mark a resource as initialized.
+        /// This should be called after directly mutating resource_pool[i] to ensure
+        /// the resource can be serialized. Prefer using setResource() or getResourcePtrMut()
+        /// which automatically mark resources as initialized.
+        pub fn markResourceInitialized(self: *Self, comptime R: type) void {
+            if (resource_pool_length > 0) {
+                const id = comptime getResourceId(R);
                 self.resource_initialized.set(id);
             }
         }
@@ -1011,6 +1027,7 @@ test "Resource basic access" {
 
     // Initialize resource
     world.resource_pool[0] = .{ .gravity = 9.8, .max_speed = 100.0 };
+    world.markResourceInitialized(GameConfig);
 
     // Get resource via ID
     try std.testing.expectEqual(@as(u16, 0), TestWorld.getResourceId(GameConfig));
@@ -1038,6 +1055,7 @@ test "Resource mutation via pointer" {
 
     // Initialize resource
     world.resource_pool[0] = .{ .score = 0, .level = 1 };
+    world.markResourceInitialized(GameState);
 
     // Get mutable pointer and modify
     const state = world.getResourcePtrMut(GameState);
@@ -1078,6 +1096,9 @@ test "Multiple resources" {
     world.resource_pool[0] = .{ .gravity = 9.8 };
     world.resource_pool[1] = .{ .score = 0 };
     world.resource_pool[2] = .{ .volume = 0.8, .muted = false };
+    world.markResourceInitialized(GameConfig);
+    world.markResourceInitialized(GameState);
+    world.markResourceInitialized(AudioSettings);
 
     // Verify resource IDs
     try std.testing.expectEqual(@as(u16, 0), TestWorld.getResourceId(GameConfig));
@@ -1118,6 +1139,7 @@ test "Resource in system function" {
 
     // Initialize resource
     world.resource_pool[0] = .{ .dt = 0.016 }; // 60 FPS
+    world.markResourceInitialized(DeltaTime);
 
     // Create entities
     const e1 = world.createEntity();
@@ -1163,6 +1185,7 @@ test "Resource mutation in system function" {
 
     // Initialize resource
     world.resource_pool[0] = .{ .points = 0, .combo = 0 };
+    world.markResourceInitialized(Score);
 
     // Create enemies
     const e1 = world.createEntity();
@@ -1214,6 +1237,8 @@ test "System with multiple resources" {
     // Initialize resources
     world.resource_pool[0] = .{ .dt = 0.016 };
     world.resource_pool[1] = .{ .speed_multiplier = 2.0 };
+    world.markResourceInitialized(DeltaTime);
+    world.markResourceInitialized(GameConfig);
 
     // Create entity
     const e1 = world.createEntity();
@@ -1268,6 +1293,7 @@ test "System with resource, allocator, query, and commands" {
 
     // Initialize resource
     world.resource_pool[0] = .{ .value = 0 };
+    world.markResourceInitialized(Score);
 
     // Create enemies
     const e1 = world.createEntity();
@@ -1307,6 +1333,7 @@ test "World with components and resources together" {
 
     // Initialize resource
     world.resource_pool[0] = .{ .dt = 0.016 };
+    world.markResourceInitialized(DeltaTime);
 
     // Create entity with components
     const entity = world.createEntity();
@@ -1905,4 +1932,67 @@ test "Resource initialization tracking" {
     try world.setResource(Score, .{ .points = 100 });
     try std.testing.expect(world.isResourceInitialized(GameConfig));
     try std.testing.expect(world.isResourceInitialized(Score));
+}
+
+test "getResourcePtrMut marks resource as initialized" {
+    const GameConfig = struct { gravity: f32 };
+    const Score = struct { points: i32 };
+
+    const TestWorld = World(struct {}, struct { GameConfig, Score }, struct {});
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var world = TestWorld.init(allocator);
+    defer world.deinit();
+
+    // Initially, resources are not initialized
+    try std.testing.expect(!world.isResourceInitialized(GameConfig));
+    try std.testing.expect(!world.isResourceInitialized(Score));
+
+    // Get mutable pointer and modify - this should mark as initialized
+    const config = world.getResourcePtrMut(GameConfig);
+    config.gravity = 9.8;
+    try std.testing.expect(world.isResourceInitialized(GameConfig));
+
+    // Verify serialization succeeds after using getResourcePtrMut
+    const score = world.getResourcePtrMut(Score);
+    score.points = 100;
+    try std.testing.expect(world.isResourceInitialized(Score));
+
+    // Both resources should now be serializable
+    var buffer: std.ArrayList(u8) = .{};
+    defer buffer.deinit(allocator);
+    try world.serialize(buffer.writer(allocator));
+    try std.testing.expect(buffer.items.len > 0);
+}
+
+test "markResourceInitialized for direct resource_pool access" {
+    const GameConfig = struct { gravity: f32 };
+
+    const TestWorld = World(struct {}, struct { GameConfig }, struct {});
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var world = TestWorld.init(allocator);
+    defer world.deinit();
+
+    // Directly assign to resource_pool (not recommended but supported)
+    world.resource_pool[0] = .{ .gravity = 9.8 };
+
+    // Resource is not yet marked as initialized
+    try std.testing.expect(!world.isResourceInitialized(GameConfig));
+
+    // Mark it initialized
+    world.markResourceInitialized(GameConfig);
+    try std.testing.expect(world.isResourceInitialized(GameConfig));
+
+    // Verify serialization succeeds
+    var buffer: std.ArrayList(u8) = .{};
+    defer buffer.deinit(allocator);
+    try world.serialize(buffer.writer(allocator));
+    try std.testing.expect(buffer.items.len > 0);
 }

--- a/src/world.zig
+++ b/src/world.zig
@@ -160,6 +160,7 @@ pub fn World(Components: anytype, Resources: anytype, Events: anytype) type {
         entity_registry: EntityRegistry,
         component_pool: ComponentPoolType,
         resource_pool: ResourcePoolType,
+        resource_initialized: if (resource_pool_length == 0) void else std.StaticBitSet(resource_pool_length),
         event_pool: EventPoolType,
         groups: ArrayList(GroupInfo),
         command_buffer: CommandBuffer(Self),
@@ -175,7 +176,8 @@ pub fn World(Components: anytype, Resources: anytype, Events: anytype) type {
                     }
                     break :init pool;
                 },
-                .resource_pool = undefined,
+                .resource_pool = if (resource_pool_length == 0) .{} else std.mem.zeroes(ResourcePoolType),
+                .resource_initialized = if (resource_pool_length == 0) {} else std.StaticBitSet(resource_pool_length).initEmpty(),
                 .event_pool = init: {
                     var pool: EventPoolType = undefined;
                     inline for (event_fields, 0..) |field, i| {
@@ -356,6 +358,15 @@ pub fn World(Components: anytype, Resources: anytype, Events: anytype) type {
         pub fn setResource(self: *Self, comptime R: type, resource: R) !void {
             const id = comptime getResourceId(R);
             self.resource_pool[id] = resource;
+            if (resource_pool_length > 0) {
+                self.resource_initialized.set(id);
+            }
+        }
+
+        pub fn isResourceInitialized(self: *const Self, comptime R: type) bool {
+            if (resource_pool_length == 0) return false;
+            const id = comptime getResourceId(R);
+            return self.resource_initialized.isSet(id);
         }
 
         pub fn getEventStoragePtrMut(self: *Self, comptime E: type) *EventStorage(E) {
@@ -1805,4 +1816,93 @@ test "World recommended usage pattern - validate groups upfront" {
     // Fast iteration over group components
     const positions = world.getGroupComponents(struct { Position, Velocity }, Position).?;
     try std.testing.expectEqual(@as(f32, 10.0), positions[0].x);
+}
+
+test "Serialization fails for uninitialized resources" {
+    const Position = struct { x: f32, y: f32 };
+    const GameConfig = struct { gravity: f32 };
+    const Score = struct { points: i32 };
+
+    const TestWorld = World(struct { Position }, struct { GameConfig, Score }, struct {});
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var world = TestWorld.init(allocator);
+    defer world.deinit();
+
+    // Create an entity
+    const entity = world.createEntity();
+    try world.addComponent(entity, Position, .{ .x = 10.0, .y = 20.0 });
+
+    // Initialize only one resource, leaving the other uninitialized
+    try world.setResource(GameConfig, .{ .gravity = 9.8 });
+
+    // Try to serialize - should fail because Score is not initialized
+    var buffer: std.ArrayList(u8) = .{};
+    defer buffer.deinit(allocator);
+
+    const result = world.serialize(buffer.writer(allocator));
+    try std.testing.expectError(error.UninitializedResource, result);
+}
+
+test "Serialization succeeds when all resources are initialized" {
+    const Position = struct { x: f32, y: f32 };
+    const GameConfig = struct { gravity: f32 };
+    const Score = struct { points: i32 };
+
+    const TestWorld = World(struct { Position }, struct { GameConfig, Score }, struct {});
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var world = TestWorld.init(allocator);
+    defer world.deinit();
+
+    // Create an entity
+    const entity = world.createEntity();
+    try world.addComponent(entity, Position, .{ .x = 10.0, .y = 20.0 });
+
+    // Initialize all resources
+    try world.setResource(GameConfig, .{ .gravity = 9.8 });
+    try world.setResource(Score, .{ .points = 100 });
+
+    // Serialize - should succeed
+    var buffer: std.ArrayList(u8) = .{};
+    defer buffer.deinit(allocator);
+
+    try world.serialize(buffer.writer(allocator));
+
+    // Verify serialization produced data
+    try std.testing.expect(buffer.items.len > 0);
+}
+
+test "Resource initialization tracking" {
+    const GameConfig = struct { gravity: f32 };
+    const Score = struct { points: i32 };
+
+    const TestWorld = World(struct {}, struct { GameConfig, Score }, struct {});
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var world = TestWorld.init(allocator);
+    defer world.deinit();
+
+    // Initially, no resources should be initialized
+    try std.testing.expect(!world.isResourceInitialized(GameConfig));
+    try std.testing.expect(!world.isResourceInitialized(Score));
+
+    // Set GameConfig
+    try world.setResource(GameConfig, .{ .gravity = 9.8 });
+    try std.testing.expect(world.isResourceInitialized(GameConfig));
+    try std.testing.expect(!world.isResourceInitialized(Score));
+
+    // Set Score
+    try world.setResource(Score, .{ .points = 100 });
+    try std.testing.expect(world.isResourceInitialized(GameConfig));
+    try std.testing.expect(world.isResourceInitialized(Score));
 }


### PR DESCRIPTION
Previously, World.init left resource_pool uninitialized (set to undefined), causing serialization to leak random memory into save files. This could lead to corrupt save files, nondeterministic deserialization failures, and potential security issues.

Changes:
- Zero-initialize resource_pool in World.init using std.mem.zeroes()
- Add resource_initialized bitset (std.StaticBitSet) to track which resources have been set
- Update setResource() to mark resources as initialized
- Add isResourceInitialized() helper method to check initialization state
- Modify serialize() to fail fast with error.UninitializedResource when encountering unset resources
- Update deserialize() to mark resources as initialized after loading
- Add comprehensive tests to verify serialization behavior:
  * Test that serialization fails for uninitialized resources
  * Test that serialization succeeds when all resources are initialized
  * Test resource initialization tracking

This ensures that serialization only writes valid, initialized resource data and prevents undefined behavior from propagating into save files.