### PR TITLE
Remove non-owning groups references and validation

### DIFF
--- a/src/query/CLAUDE.md
+++ b/src/query/CLAUDE.md
@@ -62,7 +62,7 @@ tags: TagQuery(struct { Active, ?Sleeping, Exclude(Dead) })
 
 ## Group(struct { ... })
 
-Pre-organized multi-component iteration. Supports three group types:
+Pre-organized multi-component iteration. Supports two group types:
 
 ### Group Types
 
@@ -70,7 +70,6 @@ Pre-organized multi-component iteration. Supports three group types:
 |------|--------|------------------|-----------------|----------|
 | **Full-owning** | `struct { A, B }` | All | None | Exclusive hot-path access |
 | **Partial-owning** | `struct { A, Free(B) }` | Some | Some | Share components, optimize hot path |
-| **Non-owning** | `struct { Free(A), Free(B) }` | None | All | Maximum sharing (not yet implemented) |
 
 ### Full-Owning Groups (Default)
 

--- a/src/query/filter.zig
+++ b/src/query/filter.zig
@@ -461,17 +461,6 @@ pub fn Group(comptime GroupComponents: type) type {
     if (component_fields.len == 0) @compileError("Group must have at least one component");
     const length = component_fields.len;
 
-    // Separate owned and free components at compile time
-    const owned_count = comptime blk: {
-        var count: usize = 0;
-        for (component_fields) |field| {
-            const ComponentType = extractFree(field.type);
-            if (isTagComponent(ComponentType)) @compileError("Group cannot consist of tag components");
-            if (!isFree(field.type)) count += 1;
-        }
-        break :blk count;
-    };
-
     const GroupComponentPoolType = construct_component_pool: {
         var sparse_set_fields: [length]StructField = undefined;
         inline for (component_fields, 0..) |field, i| {

--- a/src/query/filter.zig
+++ b/src/query/filter.zig
@@ -538,10 +538,7 @@ pub fn Group(comptime GroupComponents: type) type {
 
         pub fn getEntities(self: Self) []const Entity {
             // Use the first owned component's sparse set to get group entities
-            // If no owned components (non-owning group), panic for now
-            if (owned_count == 0) {
-                @panic("Non-owning groups not yet fully implemented");
-            }
+            // (At least one owned component is guaranteed by createGroup validation)
             return inline for (component_fields, 0..) |field, i| {
                 if (!isFree(field.type)) break self.group_component_pool[i].getGroupEntities();
             } else unreachable;
@@ -850,7 +847,7 @@ pub fn Exclude(comptime C: type) type {
     };
 }
 
-/// Free marks a component as "free" (not owned) in a partial-owning or non-owning group.
+/// Free marks a component as "free" (not owned) in a partial-owning group.
 /// Free components are accessed via indirection (sparse set lookup) rather than direct array access.
 /// This allows components to be owned by one group while being used as free in other groups.
 ///

--- a/src/query/filter_test.zig
+++ b/src/query/filter_test.zig
@@ -1653,13 +1653,6 @@ test "Partial-owning group - shared free component" {
     try std.testing.expectEqual(@as(usize, 1), group2.getEntities().len);
 }
 
-// TODO: Implement non-owning groups (requires separate entity list storage)
-// Non-owning groups need their own sparse set to store entity IDs
-// since no components are owned and thus organized
-test "Non-owning group - basic functionality (TODO)" {
-    return error.SkipZigTest;
-}
-
 test "Ownership conflict detection" {
     const Position = struct { x: f32, y: f32 };
     const Velocity = struct { dx: f32, dy: f32 };

--- a/src/world.zig
+++ b/src/world.zig
@@ -484,7 +484,7 @@ pub fn World(Components: anytype, Resources: anytype, Events: anytype) type {
             return entity;
         }
 
-        /// Create a group for the given component types (supports full-owning, partial-owning, and non-owning groups)
+        /// Create a group for the given component types (supports full-owning and partial-owning groups)
         pub fn createGroup(self: *Self, comptime GroupComponents: type) !void {
             const group_fields = comptime std.meta.fields(GroupComponents);
             if (group_fields.len == 0) @compileError("Cannot create group with zero components");
@@ -499,6 +499,12 @@ pub fn World(Components: anytype, Resources: anytype, Events: anytype) type {
             };
 
             const free_count = group_fields.len - owned_count;
+
+            // Compile-time validation: ensure at least one component is owned
+            if (owned_count == 0) {
+                @compileError("Groups must have at least one owned component. All components are marked as Free(T). " ++
+                    "Remove Free() from at least one component to create a valid group.");
+            }
 
             // Compile-time validation: ensure all component types are valid for this world
             comptime {
@@ -674,12 +680,7 @@ pub fn World(Components: anytype, Resources: anytype, Events: anytype) type {
         pub fn getGroupEntities(self: *const Self, comptime GroupComponents: type) ?[]const Entity {
             const group = self.getGroup(GroupComponents) orelse return null;
 
-            // For non-owning groups, we need separate entity tracking (TODO: implement)
-            // For now, use the first owned component if available
-            if (group.owned_component_ids.len == 0) {
-                @panic("Non-owning groups not yet fully implemented");
-            }
-
+            // Use the first owned component (guaranteed to exist by createGroup validation)
             const first_id = group.owned_component_ids[0];
 
             // Use inline for to access tuple element at runtime


### PR DESCRIPTION
Non-owning groups (where all components are Free(T)) were advertised but would panic at runtime when attempting to iterate. This change:

- Adds compile-time validation in createGroup() to ensure at least one component is owned (not Free)
- Removes panic code from getGroupEntities() and Group.getEntities() since validation prevents the error case
- Updates documentation to remove non-owning group type from tables and descriptions
- Removes skipped test for non-owning groups

Groups now support only full-owning and partial-owning configurations, with clear compile errors if all components are marked Free(T).