### PR TITLE
Add read-only resource access support

### DIFF
--- a/examples/commands_serialization.zig
+++ b/examples/commands_serialization.zig
@@ -52,8 +52,8 @@ const MovementGroup = struct { Position, Health };
 fn gameplaySystem(
     positions: sparze.SingleQuery(Position),
     healths: sparze.SingleQuery(Health),
-    score: sparze.Resource(Score),
-    time: sparze.Resource(GameTime),
+    score: sparze.ResourceMut(Score),
+    time: sparze.ResourceMut(GameTime),
 ) !void {
     // Update positions
     for (positions.components) |*pos| {

--- a/examples/resources.zig
+++ b/examples/resources.zig
@@ -78,7 +78,7 @@ fn physicsSystem(
 
 // Combat system that updates score resource
 fn combatSystem(
-    score: sparze.Resource(Score),
+    score: sparze.ResourceMut(Score),
     enemies: sparze.Query(struct { Enemy, Health, sparze.Exclude(Dead) }),
     commands: anytype,
 ) !void {
@@ -105,7 +105,7 @@ fn combatSystem(
 
 // Collectible system that updates score
 fn collectibleSystem(
-    score: sparze.Resource(Score),
+    score: sparze.ResourceMut(Score),
     player: sparze.Query(struct { Player, Position }),
     collectibles: sparze.Query(struct { Collectible, Position }),
     commands: anytype,
@@ -137,8 +137,8 @@ fn collectibleSystem(
 // Level progression system using multiple resources
 fn levelSystem(
     score: sparze.Resource(Score),
-    state: sparze.Resource(GameState),
-    config: sparze.Resource(GameConfig),
+    state: sparze.ResourceMut(GameState),
+    config: sparze.ResourceMut(GameConfig),
 ) !void {
     // Level up every 1000 points
     const new_level = @as(i32, @intFromFloat(@floor(@as(f32, @floatFromInt(score.value.points)) / 1000.0))) + 1;

--- a/src/query/filter.zig
+++ b/src/query/filter.zig
@@ -33,8 +33,10 @@ pub const FilterType = enum {
     single_tag,
     /// TagQuery filter: performs runtime intersection for multiple tag components
     tag_query,
-    /// Resource filter: provides access to a global resource
+    /// Resource filter: provides read-only access to a global resource
     resource,
+    /// ResourceMut filter: provides mutable access to a global resource
+    resource_mut,
     /// EventReader filter: reads events from the previous frame
     event_reader,
     /// EventWriter filter: writes events to the current frame
@@ -738,10 +740,55 @@ pub fn TagQuery(comptime QueryTags: type) type {
     };
 }
 
+/// Resource provides read-only access to a global resource.
+///
+/// Resources are singleton data that can be accessed from any system.
+/// Use Resource(T) for read-only access to enable potential parallel execution
+/// of systems that only read from the same resource.
+///
+/// For mutable access, use ResourceMut(T) instead.
+///
+/// Example:
+/// ```zig
+/// fn renderSystem(config: Resource(RenderConfig)) !void {
+///     // Read-only access to render configuration
+///     const width = config.value.width;
+///     const height = config.value.height;
+/// }
+/// ```
 pub fn Resource(comptime T: type) type {
     return struct {
         const Self = @This();
         pub const filter_type: FilterType = .resource;
+        pub const ResourceType = T;
+        value: *const T,
+
+        pub fn init(value: *const T) Self {
+            return .{
+                .value = value,
+            };
+        }
+    };
+}
+
+/// ResourceMut provides mutable access to a global resource.
+///
+/// Resources are singleton data that can be accessed from any system.
+/// Use ResourceMut(T) when you need to modify the resource state.
+///
+/// For read-only access, use Resource(T) instead to enable better parallelization.
+///
+/// Example:
+/// ```zig
+/// fn scoreSystem(score: ResourceMut(Score)) !void {
+///     // Mutable access to score resource
+///     score.value.points += 100;
+/// }
+/// ```
+pub fn ResourceMut(comptime T: type) type {
+    return struct {
+        const Self = @This();
+        pub const filter_type: FilterType = .resource_mut;
         pub const ResourceType = T;
         value: *T,
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -23,6 +23,7 @@ pub const TagQuery = filter_module.TagQuery;
 pub const Exclude = filter_module.Exclude;
 pub const Free = filter_module.Free;
 pub const Resource = filter_module.Resource;
+pub const ResourceMut = filter_module.ResourceMut;
 pub const EventReader = filter_module.EventReader;
 pub const EventWriter = filter_module.EventWriter;
 

--- a/src/system/system.zig
+++ b/src/system/system.zig
@@ -803,6 +803,9 @@ pub fn createSystemFunction(comptime World: type, comptime system_fn: anytype) f
                                 args[i] = ArgType.init(world);
                             },
                             .resource => {
+                                args[i] = ArgType.init(world.getResourcePtr(ArgType.ResourceType));
+                            },
+                            .resource_mut => {
                                 args[i] = ArgType.init(world.getResourcePtrMut(ArgType.ResourceType));
                             },
                             .event_reader => {

--- a/src/world.zig
+++ b/src/world.zig
@@ -25,6 +25,7 @@ pub const Group = filter_module.Group;
 pub const SingleTag = filter_module.SingleTag;
 pub const TagQuery = filter_module.TagQuery;
 pub const Resource = filter_module.Resource;
+pub const ResourceMut = filter_module.ResourceMut;
 pub const EventReader = filter_module.EventReader;
 pub const EventWriter = filter_module.EventWriter;
 pub const Free = filter_module.Free;
@@ -1172,7 +1173,7 @@ test "Resource mutation in system function" {
     const TestWorld = World(struct { Enemy }, struct { Score }, struct {});
 
     const ScoreSystem = struct {
-        fn system(score: Resource(Score), query: SingleTag(Enemy)) !void {
+        fn system(score: ResourceMut(Score), query: SingleTag(Enemy)) !void {
             for (query.entities) |_| {
                 score.value.points += 100;
                 score.value.combo += 1;
@@ -1266,7 +1267,7 @@ test "System with resource, allocator, query, and commands" {
     const ComplexSystem = struct {
         fn system(
             allocator: std.mem.Allocator,
-            score: Resource(Score),
+            score: ResourceMut(Score),
             enemies: SingleTag(Enemy),
             commands: anytype,
         ) !void {
@@ -1999,4 +2000,71 @@ test "markResourceInitialized for direct resource_pool access" {
     defer buffer.deinit(allocator);
     try world.serialize(buffer.writer(allocator));
     try std.testing.expect(buffer.items.len > 0);
+}
+
+test "Resource is read-only and ResourceMut is mutable" {
+    const GameConfig = struct { speed: f32 };
+    const Score = struct { points: i32 };
+
+    const TestWorld = World(struct {}, struct { GameConfig, Score }, struct {});
+
+    // Test read-only Resource system
+    const ReadOnlySystem = struct {
+        fn system(config: Resource(GameConfig)) !void {
+            // Read access works
+            _ = config.value.speed;
+            // Mutation would fail at compile time:
+            // config.value.speed = 100.0; // ERROR: cannot assign to constant
+        }
+    };
+
+    // Test mutable ResourceMut system
+    const MutableSystem = struct {
+        fn system(score: ResourceMut(Score), config: ResourceMut(GameConfig)) !void {
+            // Read and write access work
+            score.value.points += 100;
+            config.value.speed *= 1.5;
+        }
+    };
+
+    // Test mixed read-only and mutable access
+    const MixedSystem = struct {
+        fn system(config: Resource(GameConfig), score: ResourceMut(Score)) !void {
+            // Read from config, write to score
+            score.value.points += @as(i32, @intFromFloat(config.value.speed * 10.0));
+        }
+    };
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var world = TestWorld.init(allocator);
+    defer world.deinit();
+
+    // Initialize resources
+    world.resource_pool[0] = .{ .speed = 10.0 };
+    world.resource_pool[1] = .{ .points = 0 };
+    world.markResourceInitialized(GameConfig);
+    world.markResourceInitialized(Score);
+
+    // Run read-only system
+    try world.runSystem(ReadOnlySystem.system);
+
+    // Verify config unchanged
+    try std.testing.expectEqual(@as(f32, 10.0), world.getResource(GameConfig).speed);
+
+    // Run mutable system
+    try world.runSystem(MutableSystem.system);
+
+    // Verify both resources were modified
+    try std.testing.expectEqual(@as(f32, 15.0), world.getResource(GameConfig).speed);
+    try std.testing.expectEqual(@as(i32, 100), world.getResource(Score).points);
+
+    // Run mixed system
+    try world.runSystem(MixedSystem.system);
+
+    // Verify score was updated based on config value, but config unchanged
+    try std.testing.expectEqual(@as(i32, 250), world.getResource(Score).points); // 100 + (15.0 * 10) = 250
+    try std.testing.expectEqual(@as(f32, 15.0), world.getResource(GameConfig).speed);
 }


### PR DESCRIPTION
BREAKING CHANGE: Resource(T) is now read-only by default

Split Resource into two variants to enable better access control and potential parallelization:

- Resource(T): Read-only access with *const T
- ResourceMut(T): Mutable access with *T

Changes:
- Added ResourceMut filter type to FilterType enum
- Modified Resource(T) to provide *const T instead of *T
- Created new ResourceMut(T) for mutable access with *T
- Updated system injection to use getResourcePtr() for Resource and getResourcePtrMut() for ResourceMut
- Exported ResourceMut from root.zig and world.zig
- Updated all examples to use ResourceMut where mutation occurs
- Updated all tests to use ResourceMut where mutation occurs
- Added comprehensive test for read-only vs mutable access

Migration Guide:
Replace Resource(T) with ResourceMut(T) in systems that mutate the resource. Systems that only read can continue using Resource(T).

Before:
fn mySystem(score: Resource(Score)) !void {
    score.value.points += 100;  // mutation
}

After:
fn mySystem(score: ResourceMut(Score)) !void {
    score.value.points += 100;  // mutation allowed
}

Fixes #6