### PR TITLE
fix: validate checksum before mutating world state during deserialization

### DIFF
--- a/src/serialization/world.zig
+++ b/src/serialization/world.zig
@@ -307,6 +307,9 @@ pub fn deserializeFromFile(
         return error.EndOfStream;
     }
 
+    // Rewind to start of file (getEndPos moves cursor to EOF)
+    try file.seekTo(0);
+
     // Allocate buffer for entire file
     const data = try world.allocator.alloc(u8, @intCast(file_size));
     defer world.allocator.free(data);

--- a/src/serialization/world.zig
+++ b/src/serialization/world.zig
@@ -21,14 +21,7 @@ pub fn serialize(
     writer: anytype,
 ) !void {
     const WriterType = @TypeOf(writer);
-
-    // Adapt incoming writer to the new Io.Writer interface if needed
-    var adapt_buffer: [0]u8 = .{};
-    const Adapter = if (comptime @hasDecl(WriterType, "adaptToNewApi"))
-        @TypeOf(writer.adaptToNewApi(&adapt_buffer))
-    else
-        void;
-    var adapter: ?Adapter = null;
+    var old_adapter: ?writer_mod.OldWriterAdapter(WriterType) = null;
 
     const io_writer: *std.Io.Writer = blk: {
         switch (@typeInfo(WriterType)) {
@@ -42,12 +35,12 @@ pub fn serialize(
             break :blk &writer.interface;
         }
 
-        if (comptime @hasDecl(WriterType, "adaptToNewApi")) {
-            adapter = writer.adaptToNewApi(&adapt_buffer);
-            break :blk &adapter.?.new_interface;
+        if (comptime writer_mod.hasOldWriterApi(WriterType)) {
+            old_adapter = writer_mod.initOldWriterAdapter(writer);
+            break :blk old_adapter.?.writer();
         }
 
-        @compileError("serialize expects a writer that can be adapted to std.Io.Writer");
+        @compileError("serialize expects a std.Io.Writer or a type exposing an .interface field");
     };
 
     // Create buffered checksum writer

--- a/src/serialization/world.zig
+++ b/src/serialization/world.zig
@@ -20,8 +20,38 @@ pub fn serialize(
     comptime EventTypes: type,
     writer: anytype,
 ) !void {
+    const WriterType = @TypeOf(writer);
+
+    // Adapt incoming writer to the new Io.Writer interface if needed
+    var adapt_buffer: [0]u8 = .{};
+    const Adapter = if (comptime @hasDecl(WriterType, "adaptToNewApi"))
+        @TypeOf(writer.adaptToNewApi(&adapt_buffer))
+    else
+        void;
+    var adapter: ?Adapter = null;
+
+    const io_writer: *std.Io.Writer = blk: {
+        switch (@typeInfo(WriterType)) {
+            .pointer => |ptr| {
+                if (ptr.child == std.Io.Writer) break :blk writer;
+            },
+            else => {},
+        }
+
+        if (comptime @hasField(WriterType, "interface")) {
+            break :blk &writer.interface;
+        }
+
+        if (comptime @hasDecl(WriterType, "adaptToNewApi")) {
+            adapter = writer.adaptToNewApi(&adapt_buffer);
+            break :blk &adapter.?.new_interface;
+        }
+
+        @compileError("serialize expects a writer that can be adapted to std.Io.Writer");
+    };
+
     // Create buffered checksum writer
-    var checksum_writer = writer_mod.bufferedChecksumWriter(writer);
+    var checksum_writer = writer_mod.bufferedChecksumWriter(io_writer);
     const w = checksum_writer.writer();
 
     // Write header
@@ -242,6 +272,11 @@ pub fn deserialize(
     var payload_stream = std.io.fixedBufferStream(payload);
     const payload_reader = payload_stream.reader();
     try deserializeCore(world, ComponentTypes, ResourceTypes, EventTypes, payload_reader);
+
+    // Ensure entire payload was consumed (detect trailing data before checksum)
+    if (payload_stream.pos != payload.len) {
+        return error.TrailingDataAfterChecksum;
+    }
 }
 
 /// Convenience method to serialize World to file
@@ -337,6 +372,11 @@ pub fn deserializeFromFile(
     var payload_stream = std.io.fixedBufferStream(payload);
     const payload_reader = payload_stream.reader();
     try deserializeCore(world, ComponentTypes, ResourceTypes, EventTypes, payload_reader);
+
+    // Ensure entire payload was consumed (detect trailing data before checksum)
+    if (payload_stream.pos != payload.len) {
+        return error.TrailingDataAfterChecksum;
+    }
 }
 
 /// Core deserialization logic shared by deserialize and file I/O

--- a/src/serialization/world.zig
+++ b/src/serialization/world.zig
@@ -194,33 +194,54 @@ pub fn deserialize(
     comptime EventTypes: type,
     reader: anytype,
 ) !void {
-    // Create buffered checksum reader (excluding footer)
-    var checksum_reader = reader_mod.bufferedChecksumReader(reader);
-    const r = checksum_reader.reader();
+    // Read all data into memory to validate checksum before mutating world state
+    // This prevents leaving the world in a corrupted state if checksum validation fails
+    var data_list = std.ArrayList(u8).init(world.allocator);
+    defer data_list.deinit();
 
-    // Deserialize using core logic
-    try deserializeCore(world, ComponentTypes, ResourceTypes, EventTypes, r);
+    // Read data in chunks until EOF
+    const chunk_size = 64 * 1024; // 64 KB chunks
+    while (true) {
+        const start_len = data_list.items.len;
+        try data_list.resize(start_len + chunk_size);
 
-    // Read and validate CRC32 checksum
-    const expected_crc = try checksum_reader.readChecksumFooter();
-    try checksum_reader.validateChecksum(expected_crc);
-    
-    // Verify EOF - check buffered data first (readChecksumFooter may have prefetched extra bytes)
-    if (r.bufferedLen() > 0) {
-        return error.TrailingDataAfterChecksum;
+        var vec = [_][]u8{data_list.items[start_len..]};
+        const bytes_read = reader.readVec(&vec) catch |err| switch (err) {
+            error.EndOfStream => 0,
+            else => return err,
+        };
+
+        if (bytes_read == 0) {
+            try data_list.resize(start_len);
+            break;
+        }
+        try data_list.resize(start_len + bytes_read);
     }
-    
-    // Also check underlying reader for any remaining data
-    var peek_byte: [1]u8 = undefined;
-    const peek_slice: []u8 = &peek_byte;
-    var vec = [_][]u8{peek_slice};
-    const n = checksum_reader.underlying_reader.readVec(&vec) catch |err| switch (err) {
-        error.EndOfStream => return, // Expected - file ends after checksum
-        else => return err,
-    };
-    if (n > 0) {
-        return error.TrailingDataAfterChecksum;
+
+    const data = data_list.items;
+
+    // Verify we have at least enough data for a checksum footer
+    if (data.len < 4) {
+        return error.EndOfStream;
     }
+
+    // Split data and checksum footer
+    const payload = data[0 .. data.len - 4];
+    const footer_bytes = data[data.len - 4 ..];
+    const expected_crc = std.mem.readInt(u32, footer_bytes[0..4], .little);
+
+    // Validate checksum before deserializing
+    var crc = std.hash.Crc32.init();
+    crc.update(payload);
+    const actual_crc = crc.final();
+    if (actual_crc != expected_crc) {
+        return error.ChecksumMismatch;
+    }
+
+    // Checksum valid - now safe to deserialize into world
+    var payload_stream = std.io.fixedBufferStream(payload);
+    var payload_reader = payload_stream.reader();
+    try deserializeCore(world, ComponentTypes, ResourceTypes, EventTypes, &payload_reader.interface);
 }
 
 /// Convenience method to serialize World to file
@@ -275,16 +296,44 @@ pub fn deserializeFromFile(
     comptime EventTypes: type,
     path: []const u8,
 ) !void {
-    // Stream directly from file
+    // Read entire file into memory to validate checksum before mutating world state
+    // This prevents leaving the world in a corrupted state if checksum validation fails
     const file = try std.fs.cwd().openFile(path, .{});
     defer file.close();
 
-    // Use zero-length buffer to fully disable file-level buffering
-    var no_buffer: [0]u8 = .{};
-    var file_reader = file.reader(&no_buffer);
+    // Get file size to allocate appropriate buffer
+    const file_size = try file.getEndPos();
+    if (file_size < 4) {
+        return error.EndOfStream;
+    }
 
-    // Deserialize directly from file (deserialize() uses BufferedChecksumReader for CRC validation)
-    try deserialize(world, ComponentTypes, ResourceTypes, EventTypes, &file_reader.interface);
+    // Allocate buffer for entire file
+    const data = try world.allocator.alloc(u8, @intCast(file_size));
+    defer world.allocator.free(data);
+
+    // Read entire file
+    const bytes_read = try file.readAll(data);
+    if (bytes_read != file_size) {
+        return error.EndOfStream;
+    }
+
+    // Split data and checksum footer
+    const payload = data[0 .. data.len - 4];
+    const footer_bytes = data[data.len - 4 ..];
+    const expected_crc = std.mem.readInt(u32, footer_bytes[0..4], .little);
+
+    // Validate checksum before deserializing
+    var crc = std.hash.Crc32.init();
+    crc.update(payload);
+    const actual_crc = crc.final();
+    if (actual_crc != expected_crc) {
+        return error.ChecksumMismatch;
+    }
+
+    // Checksum valid - now safe to deserialize into world
+    var payload_stream = std.io.fixedBufferStream(payload);
+    var payload_reader = payload_stream.reader();
+    try deserializeCore(world, ComponentTypes, ResourceTypes, EventTypes, &payload_reader.interface);
 }
 
 /// Core deserialization logic shared by deserialize and file I/O

--- a/src/serialization/world.zig
+++ b/src/serialization/world.zig
@@ -240,8 +240,8 @@ pub fn deserialize(
 
     // Checksum valid - now safe to deserialize into world
     var payload_stream = std.io.fixedBufferStream(payload);
-    var payload_reader = payload_stream.reader();
-    try deserializeCore(world, ComponentTypes, ResourceTypes, EventTypes, &payload_reader.interface);
+    const payload_reader = payload_stream.reader();
+    try deserializeCore(world, ComponentTypes, ResourceTypes, EventTypes, payload_reader);
 }
 
 /// Convenience method to serialize World to file
@@ -335,8 +335,8 @@ pub fn deserializeFromFile(
 
     // Checksum valid - now safe to deserialize into world
     var payload_stream = std.io.fixedBufferStream(payload);
-    var payload_reader = payload_stream.reader();
-    try deserializeCore(world, ComponentTypes, ResourceTypes, EventTypes, &payload_reader.interface);
+    const payload_reader = payload_stream.reader();
+    try deserializeCore(world, ComponentTypes, ResourceTypes, EventTypes, payload_reader);
 }
 
 /// Core deserialization logic shared by deserialize and file I/O

--- a/src/serialization/writer.zig
+++ b/src/serialization/writer.zig
@@ -116,12 +116,159 @@ pub fn bufferedChecksumWriter(writer: *Io.Writer) BufferedChecksumWriter(void) {
     return BufferedChecksumWriter(void).init(writer);
 }
 
+pub fn OldWriterAdapter(comptime WriterType: type) type {
+    const TargetType = WriterTarget(WriterType);
+
+    return struct {
+        const Self = @This();
+        const Error = Io.Writer.Error;
+
+        target: WriterType,
+        interface: Io.Writer,
+
+        const vtable = Io.Writer.VTable{
+            .drain = drain,
+            .flush = flush,
+            .rebase = Io.Writer.failingRebase,
+        };
+
+        pub fn init(target: WriterType) Self {
+            return .{ .target = target, .interface = .{ .vtable = &vtable, .buffer = &.{} } };
+        }
+
+        pub fn writer(self: *Self) *Io.Writer {
+            return &self.interface;
+        }
+
+        fn drain(io_w: *Io.Writer, data: []const []const u8, splat: usize) Error!usize {
+            const self: *Self = @alignCast(@fieldParentPtr("interface", io_w));
+            var written: usize = 0;
+
+            if (data.len == 0) return written;
+
+            for (data[0 .. data.len - 1]) |chunk| {
+                written += try self.writeChunk(chunk);
+            }
+
+            const pattern = data[data.len - 1];
+            if (pattern.len == 0 or splat == 0) return written;
+
+            for (0..splat) |_| {
+                written += try self.writeChunk(pattern);
+            }
+
+            return written;
+        }
+
+        fn flush(io_w: *Io.Writer) Error!void {
+            const self: *Self = @alignCast(@fieldParentPtr("interface", io_w));
+
+            if (comptime @hasDecl(TargetType, "flush")) {
+                const target_ptr = self.targetPtr();
+                target_ptr.flush() catch return error.WriteFailed;
+            }
+        }
+
+        fn writeChunk(self: *Self, chunk: []const u8) Error!usize {
+            const target_ptr = self.targetPtr();
+            return target_ptr.write(chunk) catch return error.WriteFailed;
+        }
+
+        fn targetPtr(self: *Self) WriterPointer(WriterType) {
+            return switch (@typeInfo(WriterType)) {
+                .pointer => self.target,
+                else => &self.target,
+            };
+        }
+    };
+}
+
+pub fn WriterPointer(comptime WriterType: type) type {
+    return switch (@typeInfo(WriterType)) {
+        .pointer => WriterType,
+        else => *WriterType,
+    };
+}
+
+pub fn WriterTarget(comptime WriterType: type) type {
+    return switch (@typeInfo(WriterType)) {
+        .pointer => |ptr| ptr.child,
+        else => WriterType,
+    };
+}
+
+pub fn hasOldWriterApi(comptime WriterType: type) bool {
+    const TargetType = WriterTarget(WriterType);
+    return @hasDecl(TargetType, "write");
+}
+
+pub fn initOldWriterAdapter(writer: anytype) OldWriterAdapter(@TypeOf(writer)) {
+    const WriterType = @TypeOf(writer);
+    return OldWriterAdapter(WriterType).init(writer);
+}
+
+fn FixedBufferWriter() type {
+    return struct {
+        const Self = @This();
+        const Error = Io.Writer.Error;
+
+        buffer: []u8,
+        len: usize = 0,
+        interface: Io.Writer,
+
+        const vtable = Io.Writer.VTable{
+            .drain = drain,
+            .flush = flush,
+            .rebase = Io.Writer.failingRebase,
+        };
+
+        pub fn init(buf: []u8) Self {
+            return .{ .buffer = buf, .interface = .{ .vtable = &vtable, .buffer = &.{} } };
+        }
+
+        pub fn writer(self: *Self) *Io.Writer {
+            return &self.interface;
+        }
+
+        fn drain(io_w: *Io.Writer, data: []const []const u8, splat: usize) Error!usize {
+            const self: *Self = @alignCast(@fieldParentPtr("interface", io_w));
+            var written: usize = 0;
+
+            if (data.len == 0) return written;
+
+            for (data[0 .. data.len - 1]) |chunk| {
+                written += try self.writeChunk(chunk);
+            }
+
+            const pattern = data[data.len - 1];
+            if (pattern.len == 0 or splat == 0) return written;
+
+            for (0..splat) |_| {
+                written += try self.writeChunk(pattern);
+            }
+
+            return written;
+        }
+
+        fn flush(_: *Io.Writer) Error!void {
+            return;
+        }
+
+        fn writeChunk(self: *Self, chunk: []const u8) Error!usize {
+            const end = self.len + chunk.len;
+            if (end > self.buffer.len) return error.WriteFailed;
+
+            @memcpy(self.buffer[self.len..end], chunk);
+            self.len = end;
+            return chunk.len;
+        }
+    };
+}
+
 test "BufferedChecksumWriter basic" {
     var buffer: [1024]u8 = undefined;
-    var fbs = std.io.fixedBufferStream(&buffer);
-    var writer = fbs.writer();
-    var adapter = writer.adaptToNewApi(&[_]u8{});
-    var checksumWriter = bufferedChecksumWriter(&adapter.new_interface);
+    var writer = FixedBufferWriter().init(&buffer);
+    var checksumWriter = bufferedChecksumWriter(writer.writer());
 
     const data = "Hello, World!";
     try checksumWriter.writer().writeAll(data);
@@ -133,10 +280,8 @@ test "BufferedChecksumWriter basic" {
 
 test "BufferedChecksumWriter large data" {
     var buffer: [128 * 1024]u8 = undefined;
-    var fbs = std.io.fixedBufferStream(&buffer);
-    var writer = fbs.writer();
-    var adapter = writer.adaptToNewApi(&[_]u8{});
-    var checksumWriter = bufferedChecksumWriter(&adapter.new_interface);
+    var writer = FixedBufferWriter().init(&buffer);
+    var checksumWriter = bufferedChecksumWriter(writer.writer());
 
     // Write more than buffer size to test flushing
     const data = [_]u8{42} ** (70 * 1024);

--- a/src/serialization/writer.zig
+++ b/src/serialization/writer.zig
@@ -119,7 +119,9 @@ pub fn bufferedChecksumWriter(writer: *Io.Writer) BufferedChecksumWriter(void) {
 test "BufferedChecksumWriter basic" {
     var buffer: [1024]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buffer);
-    var checksumWriter = bufferedChecksumWriter(fbs.writer());
+    var writer = fbs.writer();
+    var adapter = writer.adaptToNewApi(&[_]u8{});
+    var checksumWriter = bufferedChecksumWriter(&adapter.new_interface);
 
     const data = "Hello, World!";
     try checksumWriter.writer().writeAll(data);
@@ -132,7 +134,9 @@ test "BufferedChecksumWriter basic" {
 test "BufferedChecksumWriter large data" {
     var buffer: [128 * 1024]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buffer);
-    var checksumWriter = bufferedChecksumWriter(fbs.writer());
+    var writer = fbs.writer();
+    var adapter = writer.adaptToNewApi(&[_]u8{});
+    var checksumWriter = bufferedChecksumWriter(&adapter.new_interface);
 
     // Write more than buffer size to test flushing
     const data = [_]u8{42} ** (70 * 1024);


### PR DESCRIPTION
Previously, `deserialize()` and `deserializeFromFile()` would mutate the world state by calling `deserializeCore()` before validating the CRC32 checksum. If a save file was corrupted or truncated, this would leave the world in a partially corrupted state after throwing error.ChecksumMismatch.

This commit fixes the issue by:

1. Reading all data into memory first (using ArrayList for streaming, file size for file-based deserialization)
2. Validating the CRC32 checksum against the footer
3. Only then deserializing into the world state via `deserializeCore()`

This ensures that if checksum validation fails, the world state remains unchanged, preventing data corruption.

Resolves P1 review comment: "Validate checksum before mutating world"