### PR TITLE
refactor: remove unnecessary error return from setResource()

### DIFF
--- a/examples/commands_serialization.zig
+++ b/examples/commands_serialization.zig
@@ -198,8 +198,8 @@ pub fn main() !void {
     defer world.deinit();
 
     // Initialize resources
-    try world.setResource(Score, .{ .points = 0, .level = 1 });
-    try world.setResource(GameTime, .{ .seconds = 0.0 });
+    world.setResource(Score, .{ .points = 0, .level = 1 });
+    world.setResource(GameTime, .{ .seconds = 0.0 });
 
     const save_path = "examples/commands_save.spze";
 

--- a/examples/resources.zig
+++ b/examples/resources.zig
@@ -176,18 +176,18 @@ pub fn main() !void {
     defer world.deinit();
 
     // Initialize all resources - REQUIRED before use
-    try world.setResource(DeltaTime, .{ .dt = 0.016 }); // 60 FPS
-    try world.setResource(Score, .{
+    world.setResource(DeltaTime, .{ .dt = 0.016 }); // 60 FPS
+    world.setResource(Score, .{
         .points = 0,
         .combo = 0,
         .high_score = 0,
     });
-    try world.setResource(GameConfig, .{
+    world.setResource(GameConfig, .{
         .gravity = 9.8,
         .max_speed = 100.0,
         .friction = 0.1,
     });
-    try world.setResource(GameState, .{
+    world.setResource(GameState, .{
         .level = 1,
         .paused = false,
     });

--- a/examples/serialization.zig
+++ b/examples/serialization.zig
@@ -75,8 +75,8 @@ fn createTestWorld(allocator: std.mem.Allocator) !World {
     var world = World.init(allocator);
 
     // Initialize resources
-    try world.setResource(DeltaTime, .{ .dt = 0.016 });
-    try world.setResource(Score, .{ .points = 1000, .combo = 5 });
+    world.setResource(DeltaTime, .{ .dt = 0.016 });
+    world.setResource(Score, .{ .points = 1000, .combo = 5 });
 
     // Create player entity
     const player = world.createEntity();

--- a/examples/serialization_exclusion.zig
+++ b/examples/serialization_exclusion.zig
@@ -63,12 +63,12 @@ fn createTestWorld(allocator: std.mem.Allocator) !World {
     var world = World.init(allocator);
 
     // Initialize persistent resources
-    try world.setResource(GameConfig, GameConfig{ .gravity = 9.8, .max_speed = 50.0 });
+    world.setResource(GameConfig, GameConfig{ .gravity = 9.8, .max_speed = 50.0 });
 
     // Initialize transient resources (won't be saved)
     var player_name: [32]u8 = undefined;
     @memcpy(player_name[0..7], "Player1");
-    try world.setResource(SessionData, SessionData{ .player_name = player_name, .login_time = 12345 });
+    world.setResource(SessionData, SessionData{ .player_name = player_name, .login_time = 12345 });
 
     // Create player entity with both persistent and transient components
     const player = world.createEntity();

--- a/src/system/system.zig
+++ b/src/system/system.zig
@@ -312,11 +312,11 @@ pub fn Commands(comptime World: type) type {
         /// Example:
         /// ```zig
         /// fn setupSystem(commands: anytype) !void {
-        ///     try commands.setResource(DeltaTime, .{ .dt = 0.016 });
+        ///     commands.setResource(DeltaTime, .{ .dt = 0.016 });
         /// }
         /// ```
-        pub fn setResource(self: Self, comptime R: type, resource: R) !void {
-            return self.world.setResource(R, resource);
+        pub fn setResource(self: Self, comptime R: type, resource: R) void {
+            self.world.setResource(R, resource);
         }
 
         /// Get a copy of a resource value (immediate execution).

--- a/src/system/system_commands_resource_tests.zig
+++ b/src/system/system_commands_resource_tests.zig
@@ -17,7 +17,7 @@ test "Commands.setResource marks resource as initialized" {
 
     const SetResourceSystem = struct {
         fn system(commands: anytype) !void {
-            try commands.setResource(GameConfig, .{ .gravity = 9.8 });
+            commands.setResource(GameConfig, .{ .gravity = 9.8 });
         }
     };
 
@@ -47,7 +47,7 @@ test "Commands.getResource with initialized resource" {
     defer world.deinit();
 
     // Initialize resource
-    try world.setResource(Score, .{ .points = 100 });
+    world.setResource(Score, .{ .points = 100 });
 
     const ReadResourceSystem = struct {
         fn system(commands: anytype) !void {
@@ -73,7 +73,7 @@ test "Commands.getResourcePtr and getResourcePtrMut" {
     defer world.deinit();
 
     // Initialize resource
-    try world.setResource(GameState, .{ .level = 1, .score = 0 });
+    world.setResource(GameState, .{ .level = 1, .score = 0 });
 
     const MutateResourceSystem = struct {
         fn system(commands: anytype) !void {
@@ -131,7 +131,7 @@ test "Commands.tryGetResource succeeds when initialized" {
     defer world.deinit();
 
     // Initialize resource
-    try world.setResource(GameConfig, .{ .gravity = 9.8 });
+    world.setResource(GameConfig, .{ .gravity = 9.8 });
 
     const TryGetSystem = struct {
         fn system(commands: anytype) !void {
@@ -165,7 +165,7 @@ test "Commands.tryGetResourceMut error handling" {
     try world.runSystem(TryGetMutUninitializedSystem.system);
 
     // Initialize resource
-    try world.setResource(Score, .{ .points = 0 });
+    world.setResource(Score, .{ .points = 0 });
 
     const TryGetMutSuccessSystem = struct {
         fn system(commands: anytype) !void {
@@ -243,7 +243,7 @@ test "Commands.isResourceInitialized check" {
             try std.testing.expect(!commands.isResourceInitialized(GameConfig));
 
             // Initialize it
-            try commands.setResource(GameConfig, .{ .gravity = 9.8 });
+            commands.setResource(GameConfig, .{ .gravity = 9.8 });
 
             // Should be initialized now
             try std.testing.expect(commands.isResourceInitialized(GameConfig));
@@ -319,7 +319,7 @@ test "Commands resource operations are immediate" {
     const ImmediateSystem = struct {
         fn system(commands: anytype) !void {
             // Set resource
-            try commands.setResource(Score, .{ .points = 100 });
+            commands.setResource(Score, .{ .points = 100 });
 
             // Immediately readable (not deferred like component operations)
             const score = commands.getResource(Score);

--- a/src/world.zig
+++ b/src/world.zig
@@ -486,7 +486,7 @@ pub fn World(Components: anytype, Resources: anytype, Events: anytype) type {
             return &self.resource_pool[id];
         }
 
-        pub fn setResource(self: *Self, comptime R: type, resource: R) !void {
+        pub fn setResource(self: *Self, comptime R: type, resource: R) void {
             const id = comptime getResourceId(R);
             self.resource_pool[id] = resource;
             if (comptime resource_pool_length > 0) {
@@ -511,7 +511,7 @@ pub fn World(Components: anytype, Resources: anytype, Events: anytype) type {
                 .@"struct" => |struct_info| {
                     inline for (struct_info.fields) |field| {
                         const ResourceType = @TypeOf(@field(resources, field.name));
-                        try self.setResource(ResourceType, @field(resources, field.name));
+                        self.setResource(ResourceType, @field(resources, field.name));
                     }
                 },
                 else => @compileError("initResources expects a struct literal"),
@@ -1953,7 +1953,7 @@ test "Serialization fails for uninitialized resources" {
     try world.addComponent(entity, Position, .{ .x = 10.0, .y = 20.0 });
 
     // Initialize only one resource, leaving the other uninitialized
-    try world.setResource(GameConfig, .{ .gravity = 9.8 });
+    world.setResource(GameConfig, .{ .gravity = 9.8 });
 
     // Try to serialize - should fail because Score is not initialized
     var buffer: std.ArrayList(u8) = .{};
@@ -1982,8 +1982,8 @@ test "Serialization succeeds when all resources are initialized" {
     try world.addComponent(entity, Position, .{ .x = 10.0, .y = 20.0 });
 
     // Initialize all resources
-    try world.setResource(GameConfig, .{ .gravity = 9.8 });
-    try world.setResource(Score, .{ .points = 100 });
+    world.setResource(GameConfig, .{ .gravity = 9.8 });
+    world.setResource(Score, .{ .points = 100 });
 
     // Serialize - should succeed
     var buffer: std.ArrayList(u8) = .{};
@@ -2013,12 +2013,12 @@ test "Resource initialization tracking" {
     try std.testing.expect(!world.isResourceInitialized(Score));
 
     // Set GameConfig
-    try world.setResource(GameConfig, .{ .gravity = 9.8 });
+    world.setResource(GameConfig, .{ .gravity = 9.8 });
     try std.testing.expect(world.isResourceInitialized(GameConfig));
     try std.testing.expect(!world.isResourceInitialized(Score));
 
     // Set Score
-    try world.setResource(Score, .{ .points = 100 });
+    world.setResource(Score, .{ .points = 100 });
     try std.testing.expect(world.isResourceInitialized(GameConfig));
     try std.testing.expect(world.isResourceInitialized(Score));
 }
@@ -2041,8 +2041,8 @@ test "getResourcePtrMut allows mutation after initialization" {
     try std.testing.expect(!world.isResourceInitialized(Score));
 
     // Initialize resources using setResource
-    try world.setResource(GameConfig, .{ .gravity = 0.0 });
-    try world.setResource(Score, .{ .points = 0 });
+    world.setResource(GameConfig, .{ .gravity = 0.0 });
+    world.setResource(Score, .{ .points = 0 });
     try std.testing.expect(world.isResourceInitialized(GameConfig));
     try std.testing.expect(world.isResourceInitialized(Score));
 

--- a/src/world_resource_tests.zig
+++ b/src/world_resource_tests.zig
@@ -101,7 +101,7 @@ test "tryGetResource succeeds when initialized" {
     defer world.deinit();
 
     // Initialize resource
-    try world.setResource(GameConfig, .{ .gravity = 9.8, .max_speed = 100.0 });
+    world.setResource(GameConfig, .{ .gravity = 9.8, .max_speed = 100.0 });
 
     // Should succeed
     const config_ptr = try world.tryGetResource(GameConfig);
@@ -146,7 +146,7 @@ test "tryGetResourceMut succeeds when initialized" {
     defer world.deinit();
 
     // Initialize resource
-    try world.setResource(GameState, .{ .score = 0, .level = 1 });
+    world.setResource(GameState, .{ .score = 0, .level = 1 });
 
     // Should succeed and allow mutation
     const state_ptr = try world.tryGetResourceMut(GameState);
@@ -179,7 +179,7 @@ test "getResourcePtrMut does not auto-mark as initialized" {
     try std.testing.expect(!world.isResourceInitialized(GameConfig));
 
     // Initialize it properly first
-    try world.setResource(GameConfig, .{ .gravity = 9.8, .max_speed = 100.0 });
+    world.setResource(GameConfig, .{ .gravity = 9.8, .max_speed = 100.0 });
 
     // Now it should be initialized
     try std.testing.expect(world.isResourceInitialized(GameConfig));
@@ -212,7 +212,7 @@ test "setResource marks resource as initialized" {
     try std.testing.expect(!world.isResourceInitialized(GameConfig));
 
     // Set resource
-    try world.setResource(GameConfig, .{ .gravity = 9.8, .max_speed = 100.0 });
+    world.setResource(GameConfig, .{ .gravity = 9.8, .max_speed = 100.0 });
 
     // Should be marked as initialized
     try std.testing.expect(world.isResourceInitialized(GameConfig));
@@ -285,7 +285,7 @@ test "initResources can initialize subset of resources" {
     try std.testing.expect(!world.isResourceInitialized(GameConfig));
 
     // Initialize the remaining one separately
-    try world.setResource(GameConfig, .{ .gravity = 9.8 });
+    world.setResource(GameConfig, .{ .gravity = 9.8 });
     try std.testing.expect(world.isResourceInitialized(GameConfig));
 }
 
@@ -310,8 +310,8 @@ test "initialized resources work normally with assertions" {
     defer world.deinit();
 
     // Initialize resources
-    try world.setResource(GameConfig, .{ .gravity = 9.8, .max_speed = 100.0 });
-    try world.setResource(GameState, .{ .score = 0, .level = 1 });
+    world.setResource(GameConfig, .{ .gravity = 9.8, .max_speed = 100.0 });
+    world.setResource(GameState, .{ .score = 0, .level = 1 });
 
     // All getters should work fine
     const config = world.getResource(GameConfig);


### PR DESCRIPTION
## Summary

Removes unnecessary error return type from `setResource()` and `Commands.setResource()`. Both functions have no failure path, so changing from `!void` to `void` improves API consistency and removes unnecessary error handling boilerplate.

**Changes**:
- Change `World.setResource()` return type from `!void` to `void` (src/world.zig:489)
- Change `Commands.setResource()` return type from `!void` to `void` (src/system/system.zig:318)
- Remove `try` from `initResources()` internal call (src/world.zig:514)
- Remove `try` keyword from ~30 call sites across tests and examples

**Rationale**:
- **No failure path**: Function body only assigns to array and sets bit - cannot fail
- **API consistency**: Other infallible operations (like `markResourceInitialized()`) are `void`
- **Cleaner code**: Removes unnecessary error handling boilerplate throughout codebase
- **Non-breaking for most users**: Resources typically initialized at startup, not in error-handling contexts

## Test Plan

- All 153 tests pass
- All examples compile successfully
- Pure refactoring - no behavior changes

## Files Modified

- `src/world.zig` (2 locations: function signature + initResources call)
- `src/system/system.zig` (1 location: function signature)
- `src/world_resource_tests.zig` (~10 call sites)
- `src/system/system_commands_resource_tests.zig` (~8 call sites)
- `examples/serialization.zig` (2 call sites)
- `examples/commands_serialization.zig` (2 call sites)
- `examples/serialization_exclusion.zig` (2 call sites)
- `examples/resources.zig` (4 call sites)

## Related

Part of the codebase improvements from planning session. This implements Phase 4 (API Polish) from the refactoring plan.

- Follows PR #32 (zombie entity fix) and PR #33 (query liveness validation)
- Low-priority polish task, but improves overall API ergonomics

🤖 Generated with [Claude Code](https://claude.com/claude-code)